### PR TITLE
Modest Speed Increase in aaa.cpp on POSIX compliant systems

### DIFF
--- a/aaa.cpp
+++ b/aaa.cpp
@@ -1,9 +1,28 @@
-#include <iostream>
+// Uses C++17 features.
+// g++ -std=c++17 -O3 aaa.cpp -o aaa
+
+#include <cstdio>   // BUFSIZ
+#include <unistd.h> // POSIX write()
+#include <array>    // std::array()
+
+// Generates buffer of "a" into stack memory for less cache misses.
+// When on the stack, the CPU instructions can quickly access the data.
+constexpr auto genBuffer() {
+  // BUFSIZ allows us to have a more memory alligned buffer.
+  std::array<char, BUFSIZ> buf {};
+  // Fill each byte with a char.
+  for (auto &x : buf) {
+    x = 'a'; 
+  }
+  return buf;
+}
 
 int main()
 {
-  while (true){
-    std::cout << "a";
-  }
+  static constexpr auto buf = genBuffer();
+  
+  // Use POSIX file write to have the most basic syscall we can
+  // to write to the console.
+  while(write(1, buf.data(), buf.size()));
   return 0;
 }


### PR DESCRIPTION
The patch I added is similar to what is seen in GNU yes which is known for its absurd speed.

In this pull request I generate a memory aligned buffer at compile time to reduce overhead by using constexpr.

Using POSIX write, I am able to get a much closer to kernel printing as seen by my benchmarks.

Before: 41.8MiB/s
```sh
$ ./aaa | pv > /dev/null
84.7 MiB 0:00:02 [41.8MiB/s]...
```

After: 5.22GiB/s
```sh
$ ./aaa | pv > /dev/null
10.2 GiB 0:00:02 [5.22GiB/s]...
```

These new speed will be higher or lower depending on the system as memory and cpu speed can become a issue.