### PR TITLE
Add SSL

### DIFF
--- a/aaa.ssl
+++ b/aaa.ssl
@@ -1,0 +1,1 @@
+aiiailvvvvvvvvvvvvvvvvvvvtfu


### PR DESCRIPTION
SSL stands for [Stupid Stack Language](https://esolangs.org/wiki/StupidStackLanguage). SSL evaluates from left to right, using alphabet characters to manipulate items in a stack. Try the program [here](https://tinyurl.com/x59tzyhs).
There's probably a way to do this without all the v's by adding items, but I didn't want to figure that out.

There are some discrepancies between esolangs.org and the actual behavior of SSL. For example, the letter "i" should increment the first item on the stack by one according to esolangs. Instead, it increments the top item. The letter "f" is the same - it should print the first item, but instead prints the top item.
```
a     Pushes the value 0 onto the stack
ii    Each "i" increments the first item on the stack by one
a     Pushes the value 0 onto the stack
i     Increments the first (in this case, top) item on the stack by one
l     Swaps the first and second item on the stack
vvvvvvvvvvvvvvvvvvv    Each "v" increments the top item in the stack by 5
---------------------------------------------------------------------------------
The top (second) item in the stack is now 97, the ASCII code for "a"
The bottom (first) item is 1
---------------------------------------------------------------------------------
t     If the first item on the stack (in this case, 1) is 0, skips to the next "u". Otherwise, does nothing
f     Prints the first (in this case, top) item in the stack as an ASCII character
u     If the first item on the stack is not zero, jumps back to the nearest "t". Otherwise, does nothing
```