### PR TITLE
Optimize aaa.asm and fix section bug

### DIFF
--- a/aaa.asm
+++ b/aaa.asm
@@ -1,17 +1,11 @@
-; nasm -f elf64 -o aaa.o aaa.asm && ld -o aaa aaa.o && ./aaa
+; "Yeah I write code"
+    db 0xB8
+    dd 0q1
+    dd 0xC289 << (0x2 << 0q2 << 0b1) | 0x4288C789
+    dw 0x348D & -1
+    db 0x5 | 0b00100000 ^ ~0xFF
+    dd because_im
+    dd -9.76233889780912372017480E+36
 
-SECTION .data
-A: DB 'a'
-
-SECTION .text
-GLOBAL _start
-
-_start:
-        MOV RAX, 1
-        MOV RDI, RAX
-        MOV RDX, RAX
-        MOV RSI, A
-
-LOOP:
-        SYSCALL
-        JMP LOOP
+because_im:
+    db ~0x9E

--- a/aaa.asm
+++ b/aaa.asm
@@ -1,19 +1,17 @@
 ; nasm -f elf64 -o aaa.o aaa.asm && ld -o aaa aaa.o && ./aaa
 
-SECTION .DATA:
-  A: DB 'a'
-  A_LEN: EQU $ - A
+SECTION .data
+A: DB 'a'
 
-SECTION .TEXT:
-  GLOBAL _start
+SECTION .text
+GLOBAL _start
 
-  PRINT_A:
-    MOV RAX, 1
-    MOV RDI, 1
-    MOV RSI, A
-    MOV RDX, A_LEN
-    SYSCALL
-    JMP PRINT_A
+_start:
+        MOV RAX, 1
+        MOV RDI, RAX
+        MOV RDX, RAX
+        MOV RSI, A
 
-  _start:
-    JMP PRINT_A
+LOOP:
+        SYSCALL
+        JMP LOOP

--- a/aaa.c
+++ b/aaa.c
@@ -1,9 +1,7 @@
-#include <stdio.h>
 #include "aaa.h"
 
-a aa aaa aaaa aaaaa
-  aaaaaa aaa aaaaaaa aaaa aaaaa
-    aaaaaaaa aaa aaaaaaaaa aaaaaaaaaa aaaaaaaaaaa aaaa aaaaaaaaaaaa
-  aaaaaaaaaaaaaaa
-  aaaaaaaaaaaaa aaaaaaaaaaaaaa aaaaaaaaaaaa
-aaaaaaaaaaaaaaa
+a aa aaa aaaa
+aaaaaaaa
+aaaaa aaa aaaaaa aaaa
+    aaaaaaa aaa aaaaaaaaaa aaaa aaaaaaaaaaa
+aaaaaaaaa

--- a/aaa.h
+++ b/aaa.h
@@ -1,15 +1,13 @@
+#include <stdio.h>
+
 #define a int
 #define aa main
 #define aaa (
 #define aaaa )
-#define aaaaa {
-#define aaaaaa while
-#define aaaaaaa 1
-#define aaaaaaaa printf
-#define aaaaaaaaa "%s"
-#define aaaaaaaaaa ,
-#define aaaaaaaaaaa "a"
-#define aaaaaaaaaaaa ;
-#define aaaaaaaaaaaaa return
-#define aaaaaaaaaaaaaa 0
-#define aaaaaaaaaaaaaaa }
+#define aaaaa while
+#define aaaaaa 1
+#define aaaaaaa putchar
+#define aaaaaaaa {
+#define aaaaaaaaa }
+#define aaaaaaaaaa 'a'
+#define aaaaaaaaaaa ;


### PR DESCRIPTION
Extra details:

Shrunk the program and made the loop more efficient. Takes advantage of the fact that RAX holds the number of bytes written via each SYSCALL, the number of bytes written will always be exactly 1 (in normal scenarios), and the x86_64 system call for 'write' happens to be 1. This allows the entire loop to execute with a single instruction in the body and shrinks the overall program from 32 bytes to 26 bytes.

If the user is running a Linux kernel that zeroes registers on program start (Debian is known to do this), the program can be shrunk further down to 24 bytes by replacing 'MOV RAX, 1' with 'INC RAX'.

Additionally, the assembled program no longer gives a segmentation fault error.